### PR TITLE
Fix handling of --streams in cli

### DIFF
--- a/trackstudio/cli.py
+++ b/trackstudio/cli.py
@@ -62,7 +62,9 @@ def run(streams, config, tracker, merger, port, host, share, no_browser, vision_
 
     # Use streams from command line or config
     if config_data.get("rtsp_streams") is None:
-        list(streams) if streams else ["rtsp://localhost:8554/camera0", "rtsp://localhost:8554/camera1"]
+        config_data["rtsp_streams"] = (
+            [*streams] if streams else ["rtsp://localhost:8554/camera0", "rtsp://localhost:8554/camera1"]
+        )
 
     # Import here to avoid circular imports
     from . import launch  # noqa: PLC0415


### PR DESCRIPTION
## Summary
Fixes #1 .
The --streams in cli was not working because click was throwing the error when converting the argument tuples into a list.  
Unpacking it worked.